### PR TITLE
add `libc6-compat` for Hashicorp Boundary provider.

### DIFF
--- a/runner-base.Dockerfile
+++ b/runner-base.Dockerfile
@@ -49,6 +49,7 @@ RUN apk update && \
     busybox \
     ca-certificates \
     git \
+    libc6-compat \
     gnupg \
     libcrypto3=${LIBCRYPTO_VERSION} \
     libssl3=${LIBCRYPTO_VERSION} \


### PR DESCRIPTION
There is an outstanding bugreport since 04/2023 :sob:
https://github.com/hashicorp/terraform-provider-boundary/issues/384